### PR TITLE
Ability to override hooks

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -9,6 +9,18 @@ const { addCucumberPreprocessorPlugin } = require("@badeball/cypress-cucumber-pr
 const { defineConfig } = require("cypress");
 const { DigyRunner } = require("@digy4/digyrunner-cypress");
 
+const plugin1 = (on) => {
+  on('before:run', (details) => console.log('[Plugin #1] Running before:run'));
+  on('after:spec', (details) => console.log('[Plugin #1] Running after:spec'));
+  on('after:run', (details) => console.log('[Plugin #1] Running after:run'));
+};
+
+const plugin2 = (on) => {
+  on('before:run', (details) => console.log('[Plugin #2] Running before:run'));
+  on('after:spec', (details) => console.log('[Plugin #2] Running after:spec'));
+  on('after:run', (details) => console.log('[Plugin #2] Running after:run'));
+};
+
 module.exports = defineConfig({
   videosFolder: "cypress/videos",
   video: true,
@@ -60,7 +72,7 @@ module.exports = defineConfig({
         })
       )
 
-      await DigyRunner.setup(on, config);
+      await DigyRunner.setup(on, config, [plugin1, plugin2]);
 
       return config
     },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "debug": "^4.3.4",
     "dotenv": "^16.0.3",
     "fs": "^0.0.1-security",
-    "@digy4/digyrunner-cypress": "^0.0.48"
+    "@digy4/digyrunner-cypress": "^0.0.58-alpha.3"
   },
   "devDependencies": {
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "debug": "^4.3.4",
     "dotenv": "^16.0.3",
     "fs": "^0.0.1-security",
-    "@digy4/digyrunner-cypress": "^0.0.58-alpha.3"
+    "@digy4/digyrunner-cypress": "^0.0.58"
   },
   "devDependencies": {
   }


### PR DESCRIPTION
- The problem is a Cypress limitation that they have dodged to fix for a long time and is still not fixed in Cypress.
- We have worked around the problem:
  - Client to pass in the extra hooks to Digy4 setup
  - Digy4 will remember the extra hooks and execute when Digy4 hooks are executed for the events